### PR TITLE
Moved stub implementations into zc.cimaa.stub to make them

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,10 @@ To do
 Changes
 *******
 
+- Moved stub implementations into ``zc.cimaa.stub`` to make them
+  easier to use outside of tests (e.g. when debugging real
+  installations.)
+
 0.3.1 (2015-02-07)
 ==================
 

--- a/src/zc/cimaa/agent.rst
+++ b/src/zc/cimaa/agent.rst
@@ -23,10 +23,10 @@ Define a configuration file::
   timeout = 1
 
   [database]
-  class = zc.cimaa.tests:MemoryDB
+  class = zc.cimaa.stub:MemoryDB
 
   [alerter]
-  class = zc.cimaa.tests:OutputAlerter
+  class = zc.cimaa.stub:OutputAlerter
 
 .. -> src
 
@@ -480,13 +480,13 @@ implementation allows us to specify initial faults to test this::
   timeout = 1
 
   [database]
-  class = zc.cimaa.tests:MemoryDB
+  class = zc.cimaa.stub:MemoryDB
   faults = {"test.example.com": [{"message": "Badness",
                                   "name": "//test.example.com/test/foo.txt",
                                   "severity": 50}]}
 
   [alerter]
-  class = zc.cimaa.tests:OutputAlerter
+  class = zc.cimaa.stub:OutputAlerter
 
 .. -> src
 
@@ -557,10 +557,10 @@ For example::
   sentry_dsn = http://public:secret@example.com/1
 
   [database]
-  class = zc.cimaa.tests:MemoryDB
+  class = zc.cimaa.stub:MemoryDB
 
   [alerter]
-  class = zc.cimaa.tests:OutputAlerter
+  class = zc.cimaa.stub:OutputAlerter
 
 .. -> src
 
@@ -590,10 +590,10 @@ Or::
     </logger>
 
   [database]
-  class = zc.cimaa.tests:MemoryDB
+  class = zc.cimaa.stub:MemoryDB
 
   [alerter]
-  class = zc.cimaa.tests:OutputAlerter
+  class = zc.cimaa.stub:OutputAlerter
 
 .. -> src
 

--- a/src/zc/cimaa/metrics.rst
+++ b/src/zc/cimaa/metrics.rst
@@ -28,13 +28,13 @@ specify a mtrics handler::
   directory = agent.d
 
   [database]
-  class = zc.cimaa.tests:MemoryDB
+  class = zc.cimaa.stub:MemoryDB
 
   [alerter]
-  class = zc.cimaa.tests:OutputAlerter
+  class = zc.cimaa.stub:OutputAlerter
 
   [metrics]
-  class = zc.cimaa.tests:OutputMetrics
+  class = zc.cimaa.stub:OutputMetrics
 
 .. -> src
 

--- a/src/zc/cimaa/schedule.rst
+++ b/src/zc/cimaa/schedule.rst
@@ -157,10 +157,10 @@ Let's set up an agent::
   base_interval = .1
 
   [database]
-  class = zc.cimaa.tests:MemoryDB
+  class = zc.cimaa.stub:MemoryDB
 
   [alerter]
-  class = zc.cimaa.tests:OutputAlerter
+  class = zc.cimaa.stub:OutputAlerter
 
 .. -> src
 

--- a/src/zc/cimaa/stub.py
+++ b/src/zc/cimaa/stub.py
@@ -1,0 +1,88 @@
+"""Stub plugin implementations for testing and debugging
+"""
+import gevent
+import json
+import pprint
+import time
+
+class MemoryDB:
+
+    def __init__(self, config):
+        self.faults = json.loads(config.get('faults', '{}'))
+        self.squelches = {}
+        self.agents = {}
+
+    def old_agents(self, age):
+        max_updated = time.time() - age
+        return [dict(name=k, updated=v) for k, v in self.agents.items()
+                if v < max_updated]
+
+    def get_faults(self, agent):
+        return self.faults.get(agent, ())
+
+    def set_faults(self, agent, faults, now=None):
+        times = {
+            f[name]: f['since']
+            for f in self.faults.get('agent', ()) if f['name']
+            }
+        for f in faults:
+            f['since'] = times.get(f['name'], f['updated'])
+        self.faults[agent] = faults
+        self.agents[agent] = now or time.time()
+
+    def get_squelches(self):
+        return sorted(self.squelches)
+
+    def get_squelch_details(self):
+        return [_squelch_detail(item)
+                for item in sorted(self.squelches.items())]
+
+    def squelch(self, regex, reason, user, permanent=False, now=None):
+        self.squelches[regex] = dict(
+            reason = reason,
+            user = user,
+            time = now or 1417968068.01,
+            permanent = permanent,
+            )
+
+    def unsquelch(self, regex):
+        del self.squelches[regex]
+
+    def __str__(self):
+        return pprint.pformat(self.faults)
+
+def _squelch_detail((regex, data)):
+    data = data.copy()
+    data['regex'] = regex
+    return data
+
+
+class OutputAlerter:
+
+    nfail = 0
+    sleep = 0.0
+
+    def __init__(self, config):
+        pass
+
+    def fail(self):
+        if self.nfail > 0:
+            self.nfail -= 1
+            raise ValueError('fail')
+        gevent.sleep(self.sleep)
+
+    def log(self, *args):
+        print self.__class__.__name__, ' '.join(args)
+
+    def trigger(self, name, message):
+        self.fail()
+        self.log('trigger', name, message)
+
+    def resolve(self, name):
+        self.fail()
+        self.log('resolve', name)
+
+def OutputMetrics(config):
+    def output_metrics(timestamp, name, value, units=''):
+        print timestamp, name, value, units
+    return output_metrics

--- a/src/zc/cimaa/tests.py
+++ b/src/zc/cimaa/tests.py
@@ -27,97 +27,12 @@ import re
 import StringIO
 import time
 import unittest
-
 import zc.cimaa.pagerduty # See if grequest monkey-patching breaks other things
-
-class Logging:
-
-    trace = True
-
-    def log(self, *args):
-        if self.trace:
-            print self.__class__.__name__, ' '.join(args)
-
-class MemoryDB:
-
-    def __init__(self, config):
-        self.faults = json.loads(config.get('faults', '{}'))
-        self.squelches = {}
-        self.agents = {}
-
-    def old_agents(self, age):
-        max_updated = time.time() - age
-        return [dict(name=k, updated=v) for k, v in self.agents.items()
-                if v < max_updated]
-
-    def get_faults(self, agent):
-        return self.faults.get(agent, ())
-
-    def set_faults(self, agent, faults, now=None):
-        times = {
-            f[name]: f['since']
-            for f in self.faults.get('agent', ()) if f['name']
-            }
-        for f in faults:
-            f['since'] = times.get(f['name'], f['updated'])
-        self.faults[agent] = faults
-        self.agents[agent] = now or time.time()
-
-    def get_squelches(self):
-        return sorted(self.squelches)
-
-    def get_squelch_details(self):
-        return [_squelch_detail(item)
-                for item in sorted(self.squelches.items())]
-
-    def squelch(self, regex, reason, user, permanent=False, now=None):
-        self.squelches[regex] = dict(
-            reason = reason,
-            user = user,
-            time = now or 1417968068.01,
-            permanent = permanent,
-            )
-
-    def unsquelch(self, regex):
-        del self.squelches[regex]
-
-    def __str__(self):
-        return pprint.pformat(self.faults)
-
-def _squelch_detail((regex, data)):
-    data = data.copy()
-    data['regex'] = regex
-    return data
+import zc.cimaa.stub
 
 def MetaDB(conf):
+    "Dtabase that retains state accross factory calls"
     return meta_db
-
-class OutputAlerter(Logging):
-
-    nfail = 0
-    sleep = 0.0
-
-    def __init__(self, config):
-        pass
-
-    def fail(self):
-        if self.nfail > 0:
-            self.nfail -= 1
-            raise ValueError('fail')
-        gevent.sleep(self.sleep)
-
-    def trigger(self, name, message):
-        self.fail()
-        self.log('trigger', name, message)
-
-    def resolve(self, name):
-        self.fail()
-        self.log('resolve', name)
-
-def OutputMetrics(config):
-    def output_metrics(timestamp, name, value, units=''):
-        print timestamp, name, value, units
-    return output_metrics
 
 def setUpSlack(test):
     import slacker
@@ -168,7 +83,7 @@ def setUp(test):
         test, mock.patch('raven.handlers.logging.SentryHandler'))
     setupstack.context_manager(test, mock.patch('ZConfig.configureLoggers'))
     global meta_db
-    meta_db = MemoryDB({})
+    meta_db = zc.cimaa.stub.MemoryDB({})
     setupstack.context_manager(
         test, mock.patch('getpass.getuser', lambda: 'tester'))
 


### PR DESCRIPTION
  easier to use outside of tests (e.g. when debugging real
  installations.)
