### PR TITLE
Critical flap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,9 @@ To do
 Changes
 *******
 
+- If a check test returns alternating critical/error states (it's
+  unusual for a test to return critical), the stay critical until it clears.
+
 - Moved stub implementations into ``zc.cimaa.stub`` to make them
   easier to use outside of tests (e.g. when debugging real
   installations.)

--- a/src/zc/cimaa/tests.py
+++ b/src/zc/cimaa/tests.py
@@ -118,9 +118,10 @@ def test_suite():
             'metrics.rst',
             setUp=setUpTime, tearDown=setupstack.tearDown),
         doctest.DocTestSuite('zc.cimaa.nagiosperf', optionflags=optionflags),
-        doctest.DocTestSuite(
-            'zc.cimaa.threshold', optionflags=optionflags,
-            setUp=setUpPP),
+        doctest.DocTestSuite('zc.cimaa.threshold',
+                             optionflags=optionflags,
+                             setUp=setUpPP),
+        doctest.DocTestSuite('zc.cimaa.agent', optionflags=optionflags),
         ))
     if 'DYNAMO_TEST' in os.environ:
         suite.addTest(


### PR DESCRIPTION
If a check test returns alternating critical/error states (it's
  unusual for a test to return critical), the stay critical until it clears.
