### PR TITLE
soft meta-check failures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,9 @@ To do
 Changes
 *******
 
+- If a check test returns alternating critical/error states (it's
+  unusual for a test to return critical), the stay critical until it clears.
+
 - Moved stub implementations into ``zc.cimaa.stub`` to make them
   easier to use outside of tests (e.g. when debugging real
   installations.)

--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,9 @@ Changes
   easier to use outside of tests (e.g. when debugging real
   installations.)
 
+- Check meta-failures (check had error, such as invalid output)
+  now start soft to avoid alerting on intermittent check failures.
+
 0.3.1 (2015-02-07)
 ==================
 

--- a/src/zc/cimaa/agent.py
+++ b/src/zc/cimaa/agent.py
@@ -239,7 +239,7 @@ class Check:
                     result = dict(faults=[dict(
                         name='json-error',
                         message = "%s: %s" % (v.__class__.__name__, v),
-                        severity = logging.CRITICAL,
+                        severity = logging.ERROR,
                         )])
                 faults = result['faults']
             else:
@@ -264,7 +264,7 @@ class Check:
                                            message=stdout))
                 else:
                     faults.append(monitor_error("status", stdout))
-                    status = logging.CRITICAL
+                    status = logging.ERROR
 
 
             self.thresholds(result)
@@ -285,7 +285,7 @@ class Check:
             return dict(faults=[dict(
                 name='checker',
                 message = "%s: %s" % (v.__class__.__name__, v),
-                severity = logging.CRITICAL,
+                severity = logging.ERROR,
                 updated = time.time(),
                 )])
 

--- a/src/zc/cimaa/agent.rst
+++ b/src/zc/cimaa/agent.rst
@@ -262,6 +262,9 @@ We generate a fault if json is malformed or lacks a faults property:
     >>> with open('foo.txt', 'w') as f:
     ...     f.write('{\n"faults": []')
     >>> agent.perform(0)
+    >>> agent.perform(0)
+    >>> agent.perform(0)
+    >>> agent.perform(0)
     OutputAlerter trigger //test.example.com/test/foo.txt#json-error
     ValueError: Expecting object: line 2 column 13 (char 14)
 

--- a/src/zc/cimaa/tests.py
+++ b/src/zc/cimaa/tests.py
@@ -118,9 +118,10 @@ def test_suite():
             'metrics.rst',
             setUp=setUpTime, tearDown=setupstack.tearDown),
         doctest.DocTestSuite('zc.cimaa.nagiosperf', optionflags=optionflags),
-        doctest.DocTestSuite(
-            'zc.cimaa.threshold', optionflags=optionflags,
-            setUp=setUpPP),
+        doctest.DocTestSuite('zc.cimaa.threshold',
+                             optionflags=optionflags,
+                             setUp=setUpPP),
+        doctest.DocTestSuite('zc.cimaa.agent', optionflags=optionflags),
         ))
     if 'DYNAMO_TEST' in os.environ:
         suite.addTest(


### PR DESCRIPTION
Check meta-failures (check had error, such as invalid output)
now start soft to avoid alerting on intermittent check failures.

NOTE: review previous PRs first.
