### PR TITLE
Handle dynomodb throttle

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,13 @@ To do
 Changes
 *******
 
+- Retry DynamoDB operations when exceeding the provisioned number of
+  operations, ensuring Sentry alerts are generated when Sentry is
+  configured.
+
+- Make all uncaught exceptions from Agent.perform get reported in a
+  Sentry visible way.
+
 0.5.0 (2015-02-10)
 ==================
 

--- a/src/zc/cimaa/agent-loop.rst
+++ b/src/zc/cimaa/agent-loop.rst
@@ -1,0 +1,57 @@
+Agent.loop reports exceptions
+=============================
+
+Let's set up an agent::
+
+  [agent]
+  directory = agent.d
+  base_interval = .1
+
+  [database]
+  class = zc.cimaa.stub:MemoryDB
+
+  [alerter]
+  class = zc.cimaa.stub:OutputAlerter
+
+.. -> src
+
+   >>> with open('agent.cfg', 'w') as f:
+   ...     f.write(src)
+
+   >>> import os, sys
+   >>> os.mkdir('agent.d')
+
+Create an agent:
+
+    >>> import zc.cimaa.agent
+    >>> agent = zc.cimaa.agent.Agent('agent.cfg')
+
+Register a log handler so we can inspect what happened:
+
+    >>> import logging
+    >>> import zope.testing.loggingsupport
+
+    >>> loghandler = zope.testing.loggingsupport.InstalledHandler(
+    ...     "zc.cimaa", level=logging.WARNING)
+
+When loop encounters a problem from perform, the exception is logged and
+re-raised:
+
+    >>> def bad_performance(minute):
+    ...     raise RuntimeError("something really bad happened")
+
+    >>> agent.perform = bad_performance
+
+    >>> agent.loop(1)
+    Traceback (most recent call last):
+    RuntimeError: something really bad happened
+
+    >>> print loghandler
+    zc.cimaa.agent ERROR
+      calling perform from loop:
+
+
+Clean up:
+
+    >>> agent.clear()
+    >>> loghandler.uninstall()

--- a/src/zc/cimaa/agent.py
+++ b/src/zc/cimaa/agent.py
@@ -177,7 +177,11 @@ class Agent:
             tick = now / base_interval
             itick = int(tick)
             gevent.sleep(base_interval * (1 - (tick - itick)))
-            self.perform(itick + 1)
+            try:
+                self.perform(itick + 1)
+            except Exception:
+                logger.exception("calling perform from loop:")
+                raise
             count -= 1
 
     def shutdown(self, *args):

--- a/src/zc/cimaa/dynamodb.py
+++ b/src/zc/cimaa/dynamodb.py
@@ -5,9 +5,17 @@ import boto.dynamodb2.exceptions
 import boto.dynamodb2.fields
 import boto.dynamodb2.table
 import boto.dynamodb2.types
+import logging
+import random
 import sys
 import time
 import zc.cimaa.parser
+
+
+READ_ATTEMPTS = 5
+WRITE_ATTEMPTS = 3
+
+logger = logging.getLogger(__name__)
 
 schemas = dict(
     squelches=dict(schema=[dynamodb2.fields.HashKey('regex')]),
@@ -43,8 +51,25 @@ class DB:
                     index='updated', agent__eq='_', updated__lt=max_updated)]
 
     def get_faults(self, agent):
-        faults = [_fault_data(item)
-                  for item in self.faults.query_2(agent__eq=agent)]
+        for i in range(READ_ATTEMPTS - 1):
+            try:
+                faults = [_fault_data(item)
+                          for item in self.faults.query_2(agent__eq=agent)]
+                break
+            except dynamodb2.exceptions.ProvisionedThroughputExceededException:
+                # For Sentry:
+                logger.exception("hit dynamodb throughput limit (reading)")
+                _wait("reading")
+        else:
+            try:
+                faults = [_fault_data(item)
+                          for item in self.faults.query_2(agent__eq=agent)]
+            except dynamodb2.exceptions.ProvisionedThroughputExceededException:
+                # For Sentry:
+                logger.exception("hit dynamodb throughput limit (reading)")
+                logger.error("could not read state for %s from dynamodb", agent)
+                raise RuntimeError("could not read from dynamodb in %s tries"
+                                   % READ_ATTEMPTS)
         self.last_faults[agent] = set(fault['name'] for fault in faults)
         return faults
 
@@ -54,7 +79,30 @@ class DB:
             self.get_faults(agent)
             old_faults = self.last_faults.get(agent)
 
+        for i in range(WRITE_ATTEMPTS - 1):
+            try:
+                self._set_faults(agent, faults, old_faults)
+                break
+            except dynamodb2.exceptions.ProvisionedThroughputExceededException:
+                # For Sentry:
+                logger.exception("hit dynamodb throughput limit (writing)")
+                _wait("writing")
+        else:
+            try:
+                self._set_faults(agent, faults, old_faults)
+            except dynamodb2.exceptions.ProvisionedThroughputExceededException:
+                # For Sentry:
+                logger.exception("hit dynamodb throughput limit (writing)")
+                logger.error(
+                    "could not write updates for %s to dynamodb", agent)
+                raise RuntimeError("could not update dynamodb in %s tries"
+                                   % WRITE_ATTEMPTS)
+            
+        self.last_faults[agent] = set(fault['name'] for fault in faults)
+
+    def _set_faults(self, agent, faults, old_faults):
         with self.faults.batch_write() as batch:
+            #print batch.__class__
             # Heartbeat
             batch.put_item(dict(
                 agent='_',
@@ -69,8 +117,6 @@ class DB:
                 old_faults.discard(data['name'])
             for name in old_faults:
                 batch.delete_item(agent=agent, name=name)
-
-        self.last_faults[agent] = set(fault['name'] for fault in faults)
 
     def get_squelch(self, regex):
         try:
@@ -126,6 +172,13 @@ class DB:
                  for item in self.squelches.scan()),
                 key=lambda item: ['regex']),
             )
+
+def _wait(doing_what):
+    r = random.random() * 9
+    logger.warning(
+        "exceeded provisioned throughput (%s); waiting %s seconds",
+        doing_what, r)
+    time.sleep(r)
 
 def _fault_data(item):
     data = dict(item.items())

--- a/src/zc/cimaa/dynamodb.rst
+++ b/src/zc/cimaa/dynamodb.rst
@@ -248,11 +248,11 @@ data:
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (reading)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (reading); waiting 4.23542 seconds
+      exceeded provisioned throughput; waiting 4.23542 seconds
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (reading)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (reading); waiting 0.2344 seconds
+      exceeded provisioned throughput; waiting 0.2344 seconds
 
     >>> loghandler.clear()
 
@@ -268,19 +268,19 @@ We won't wait forever, though; if it's that bad, we'll still fail:
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (reading)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (reading); waiting 7.75477721994 seconds
+      exceeded provisioned throughput; waiting 7.75477721994 seconds
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (reading)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (reading); waiting 0.394166737729 seconds
+      exceeded provisioned throughput; waiting 0.394166737729 seconds
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (reading)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (reading); waiting 8.95004687846 seconds
+      exceeded provisioned throughput; waiting 8.95004687846 seconds
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (reading)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (reading); waiting 7.63829566361 seconds
+      exceeded provisioned throughput; waiting 7.63829566361 seconds
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (reading); no more attempts
 
@@ -299,11 +299,11 @@ We'll also make repeated attempts to write to DynamoDB:
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (writing)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (writing); waiting 4.23542 seconds
+      exceeded provisioned throughput; waiting 4.23542 seconds
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (writing)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (writing); waiting 0.2344 seconds
+      exceeded provisioned throughput; waiting 0.2344 seconds
 
     >>> loghandler.clear()
 
@@ -319,11 +319,11 @@ As with reads, we won't wait forever:
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (writing)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (writing); waiting 4.23542 seconds
+      exceeded provisioned throughput; waiting 4.23542 seconds
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (writing)
     zc.cimaa.dynamodb WARNING
-      exceeded provisioned throughput (writing); waiting 0.2344 seconds
+      exceeded provisioned throughput; waiting 0.2344 seconds
     zc.cimaa.dynamodb ERROR
       hit dynamodb throughput limit (writing); no more attempts
 

--- a/src/zc/cimaa/dynamodb.rst
+++ b/src/zc/cimaa/dynamodb.rst
@@ -262,7 +262,7 @@ We won't wait forever, though; if it's that bad, we'll still fail:
     ...                zc.cimaa.dynamodb.READ_ATTEMPTS):
     ...     db.get_faults("agent")
     Traceback (most recent call last):
-    RuntimeError: could not read from dynamodb in 5 tries
+    RuntimeError: error reading dynamodb in 5 tries
 
     >>> print loghandler
     zc.cimaa.dynamodb ERROR
@@ -282,9 +282,7 @@ We won't wait forever, though; if it's that bad, we'll still fail:
     zc.cimaa.dynamodb WARNING
       exceeded provisioned throughput (reading); waiting 7.63829566361 seconds
     zc.cimaa.dynamodb ERROR
-      hit dynamodb throughput limit (reading)
-    zc.cimaa.dynamodb ERROR
-      could not read state for agent from dynamodb
+      hit dynamodb throughput limit (reading); no more attempts
 
     >>> loghandler.clear()
 
@@ -315,7 +313,7 @@ As with reads, we won't wait forever:
     ...                zc.cimaa.dynamodb.WRITE_ATTEMPTS):
     ...     db.set_faults("agent", [])
     Traceback (most recent call last):
-    RuntimeError: could not update dynamodb in 3 tries
+    RuntimeError: error writing dynamodb in 3 tries
 
     >>> print loghandler
     zc.cimaa.dynamodb ERROR
@@ -327,9 +325,7 @@ As with reads, we won't wait forever:
     zc.cimaa.dynamodb WARNING
       exceeded provisioned throughput (writing); waiting 0.2344 seconds
     zc.cimaa.dynamodb ERROR
-      hit dynamodb throughput limit (writing)
-    zc.cimaa.dynamodb ERROR
-      could not write updates for agent to dynamodb
+      hit dynamodb throughput limit (writing); no more attempts
 
     >>> loghandler.clear()
 

--- a/src/zc/cimaa/dynamodb.rst
+++ b/src/zc/cimaa/dynamodb.rst
@@ -177,7 +177,165 @@ records for other agents are not touched:
      'squelches': []}
 
 
+Exceeding provisioned throughput
+--------------------------------
+
+It's possible to exceed provisioned throughput with DynamoDB; if this
+happens on a regular basis during operation, the best thing to do is
+increased the provisioned throughput, but sometimes it's safe to
+consider a transient condition.  This has been observed when restarting
+many agents at once; the reads required for each agent to get their own
+state can easily exceed the allowed throughput.  In this case, trying
+again after a brief wait is acceptable.
+
+To deal with this, we want to ensure the throughput-exceeded events are
+tracked to allow an operations team (or a monitor) to determine the
+frequency of these events, but we don't want to cease operation.
+
+The throughput throttle can be triggered on either reads of writes;
+we'll look at the handling of each of these separately.
+
+    >>> from boto.dynamodb2.exceptions import (
+    ...     ProvisionedThroughputExceededException,
+    ...     )
+    >>> import boto.dynamodb2.exceptions
+    >>> import boto.dynamodb2.table
+    >>> import mock
+    >>> import zc.cimaa.dynamodb
+
+We'll want a side-effect that raises the appropriate exception for a
+specified number of times before allowing the operation to succeed:
+
+    >>> class State(object):
+    ...     n = 0
+
+    >>> def throttled(cls, name, ntries):
+    ...     tries = []
+    ...     real_method = getattr(cls, name)
+    ...     def tryit(*args, **kw):
+    ...         tries.append(0)
+    ...         if len(tries) > ntries:
+    ...             # Do the real thing
+    ...             return real_method(*args, **kw)
+    ...         else:
+    ...             raise ProvisionedThroughputExceededException(
+    ...                 400, "too many requests")
+    ...     return mock.patch.object(
+    ...         cls, name, autospec=True, side_effect=tryit)
+
+We'll also want a loghandler:
+
+    >>> import logging
+    >>> import zope.testing.loggingsupport
+
+    >>> loghandler = zope.testing.loggingsupport.InstalledHandler(
+    ...     "zc.cimaa", level=logging.WARNING)
+
+
+Throttled reads
+~~~~~~~~~~~~~~~
+
+If reads are throttled, we'll make a few additional attempts to read the
+data:
+
+    >>> db.last_faults.clear()
+
+    >>> with throttled(boto.dynamodb2.table.Table, "query_2", 2):
+    ...     db.get_faults("agent")
+    []
+
+    >>> print loghandler
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (reading)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (reading); waiting 4.23542 seconds
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (reading)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (reading); waiting 0.2344 seconds
+
+    >>> loghandler.clear()
+
+We won't wait forever, though; if it's that bad, we'll still fail:
+
+    >>> with throttled(boto.dynamodb2.table.Table, "query_2",
+    ...                zc.cimaa.dynamodb.READ_ATTEMPTS):
+    ...     db.get_faults("agent")
+    Traceback (most recent call last):
+    RuntimeError: could not read from dynamodb in 5 tries
+
+    >>> print loghandler
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (reading)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (reading); waiting 7.75477721994 seconds
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (reading)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (reading); waiting 0.394166737729 seconds
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (reading)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (reading); waiting 8.95004687846 seconds
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (reading)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (reading); waiting 7.63829566361 seconds
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (reading)
+    zc.cimaa.dynamodb ERROR
+      could not read state for agent from dynamodb
+
+    >>> loghandler.clear()
+
+
+Throttled writes
+~~~~~~~~~~~~~~~~
+
+We'll also make repeated attempts to write to DynamoDB:
+
+    >>> with throttled(boto.dynamodb2.table.BatchTable, "put_item", 2):
+    ...     db.set_faults("agent", [])
+
+    >>> print loghandler
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (writing)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (writing); waiting 4.23542 seconds
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (writing)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (writing); waiting 0.2344 seconds
+
+    >>> loghandler.clear()
+
+As with reads, we won't wait forever:
+
+    >>> with throttled(boto.dynamodb2.table.BatchTable, "put_item",
+    ...                zc.cimaa.dynamodb.WRITE_ATTEMPTS):
+    ...     db.set_faults("agent", [])
+    Traceback (most recent call last):
+    RuntimeError: could not update dynamodb in 3 tries
+
+    >>> print loghandler
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (writing)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (writing); waiting 4.23542 seconds
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (writing)
+    zc.cimaa.dynamodb WARNING
+      exceeded provisioned throughput (writing); waiting 0.2344 seconds
+    zc.cimaa.dynamodb ERROR
+      hit dynamodb throughput limit (writing)
+    zc.cimaa.dynamodb ERROR
+      could not write updates for agent to dynamodb
+
+    >>> loghandler.clear()
+
 Cleanup:
+
+    >>> loghandler.uninstall()
 
     >>> for table in zc.cimaa.dynamodb.schemas:
     ...     _ = getattr(db, table).delete()

--- a/src/zc/cimaa/tests.py
+++ b/src/zc/cimaa/tests.py
@@ -77,18 +77,25 @@ def setUp(test):
     setupstack.context_manager(
         test, mock.patch('socket.getfqdn', return_value='test.example.com'))
 
-    setupstack.context_manager(test, mock.patch('logging.basicConfig'))
-    setupstack.context_manager(test, mock.patch('logging.getLogger'))
-    setupstack.context_manager(
-        test, mock.patch('raven.handlers.logging.SentryHandler'))
-    setupstack.context_manager(test, mock.patch('ZConfig.configureLoggers'))
     global meta_db
     meta_db = zc.cimaa.stub.MemoryDB({})
     setupstack.context_manager(
         test, mock.patch('getpass.getuser', lambda: 'tester'))
 
-def setUpTime(test):
+def setUpLogging(test):
     setUp(test)
+    setupstack.context_manager(test, mock.patch('logging.basicConfig'))
+    setupstack.context_manager(test, mock.patch('logging.getLogger'))
+    setupstack.context_manager(
+        test, mock.patch('raven.handlers.logging.SentryHandler'))
+    setupstack.context_manager(test, mock.patch('ZConfig.configureLoggers'))
+
+def setUpDynamoDB(test):
+    setUp(test)
+    setupstack.context_manager(test, mock.patch('time.sleep'))
+
+def setUpTime(test):
+    setUpLogging(test)
     globs = test.globs
     globs['now'] = 1418487287.82
     setupstack.context_manager(
@@ -110,7 +117,7 @@ def test_suite():
                     ])
                 ) + manuel.capture.Manuel(),
             'agent.rst', 'meta.rst', 'schedule.rst', 'squelch.rst',
-            setUp=setUp, tearDown=setupstack.tearDown),
+            setUp=setUpLogging, tearDown=setupstack.tearDown),
         manuel.testing.TestSuite(
             manuel.doctest.Manuel(
                 optionflags=optionflags,
@@ -129,11 +136,12 @@ def test_suite():
                 manuel.doctest.Manuel(
                     optionflags=optionflags,
                     checker=renormalizing.OutputChecker([
-                        (re.compile(time_pat), "T")
+                        (re.compile(r"waiting \d\.\d+"), "DELAY"),
+                        (re.compile(time_pat), "T"),
                         ])
                     ) + manuel.capture.Manuel(),
                 'dynamodb.rst',
-                setUp=setUp, tearDown=setupstack.tearDown),
+                setUp=setUpDynamoDB, tearDown=setupstack.tearDown),
             )
     if 'SLACK_TOKEN' in os.environ:
         suite.addTest(

--- a/src/zc/cimaa/tests.py
+++ b/src/zc/cimaa/tests.py
@@ -124,6 +124,12 @@ def test_suite():
                 ) + manuel.capture.Manuel(),
             'metrics.rst',
             setUp=setUpTime, tearDown=setupstack.tearDown),
+        manuel.testing.TestSuite(
+            manuel.doctest.Manuel(
+                optionflags=optionflags,
+                ) + manuel.capture.Manuel(),
+            'agent-loop.rst',
+            setUp=setUpWithoutLogging, tearDown=setupstack.tearDown),
         doctest.DocTestSuite('zc.cimaa.nagiosperf', optionflags=optionflags),
         doctest.DocTestSuite('zc.cimaa.threshold',
                              optionflags=optionflags,

--- a/src/zc/cimaa/tests.py
+++ b/src/zc/cimaa/tests.py
@@ -90,7 +90,7 @@ def setUpLogging(test):
         test, mock.patch('raven.handlers.logging.SentryHandler'))
     setupstack.context_manager(test, mock.patch('ZConfig.configureLoggers'))
 
-def setUpDynamoDB(test):
+def setUpWithoutLogging(test):
     setUp(test)
     setupstack.context_manager(test, mock.patch('time.sleep'))
 
@@ -141,7 +141,7 @@ def test_suite():
                         ])
                     ) + manuel.capture.Manuel(),
                 'dynamodb.rst',
-                setUp=setUpDynamoDB, tearDown=setupstack.tearDown),
+                setUp=setUpWithoutLogging, tearDown=setupstack.tearDown),
             )
     if 'SLACK_TOKEN' in os.environ:
         suite.addTest(


### PR DESCRIPTION
Also ensures unexpected exceptions from `perform` are recorded in a Sentry-visible way.
