### PR TITLE
be much more careful about errors in agent startup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,12 @@ To do
 Changes
 *******
 
+- Report startup errors via configured logging (including Sentry)
+  instead of letting them get quietly ignored in log files.
+
+- Report errors parsing check configurations as monitored failures,
+  always critical, without causing the agent to exit.
+
 0.5.2 (2015-02-24)
 ==================
 

--- a/src/zc/cimaa/parser.py
+++ b/src/zc/cimaa/parser.py
@@ -1,5 +1,6 @@
 """Parse ConfigParser data into dicts
 """
+from ConfigParser import Error
 import ConfigParser
 
 def parse_text(text):


### PR DESCRIPTION
- Report startup errors via configured logging (including Sentry) instead of letting them get quietly ignored in log files.
- Report errors parsing check configurations as monitored failures, always critical, without causing the agent to exit.
