### PR TITLE
support non-escalating faults for monitoring failures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,9 @@ To do
 Changes
 *******
 
+- Support non-escalating faults, and use them for failures in monitors.
+  These should not be used when reporting application failures.
+
 0.5.3 (2015-03-10)
 ==================
 

--- a/src/zc/cimaa/agent.py
+++ b/src/zc/cimaa/agent.py
@@ -371,11 +371,13 @@ class Check:
             self.failures += 1
             if self.failures > self.retry:
                 for f in errors:
-                    f['severity'] = logging.CRITICAL
+                    if f.get('escalates', True):
+                        f['severity'] = logging.CRITICAL
             else:
                 for f in errors:
-                    f['message'] = "%s (%s of %s)" % (
-                        f.get('message', ''), self.failures, self.chances)
+                    if f.get('escalates', True):
+                        f['message'] = "%s (%s of %s)" % (
+                            f.get('message', ''), self.failures, self.chances)
 
         elif not critical:
             self.failures = 0
@@ -414,6 +416,7 @@ severity_names = dict(warning=logging.WARNING,
 
 def monitor_error(name, message='', prefix='', severity=logging.ERROR):
     return dict(
+        escalates=False,
         name=(prefix + 'monitor-' + name),
         message=message,
         severity=severity,

--- a/src/zc/cimaa/metrics.rst
+++ b/src/zc/cimaa/metrics.rst
@@ -155,18 +155,24 @@ Normally, performance data is ignored:
 
     >>> agent.perform(0)
     >>> print agent.db
-    {'test.example.com': [{'message': 'Missing metric (2 of 4)',
+    {'test.example.com': [{'escalates': False,
+                           'message': 'Missing metric',
                            'name': '//test.example.com/test/foo.txt#speed',
                            'severity': 40,
                            'since': 1418487287.82,
                            'updated': 1418487287.82},
-                          {'message': 'Missing metric (2 of 4)',
+                          {'escalates': False,
+                           'message': 'Missing metric',
                            'name': '//test.example.com/test/foo.txt#loudness',
                            'severity': 40,
                            'since': 1418487287.82,
                            'updated': 1418487287.82}]}
 
     >>> agent.clear()
+
+Note that the missing-metrics faults are marked as non-escalating, as
+this is considered a problem with monitoring rather than the application
+being monitored.
 
 If we want parsing of performance data, we need to use the
 ``nagios_performance`` option in the check definition:

--- a/src/zc/cimaa/threshold.py
+++ b/src/zc/cimaa/threshold.py
@@ -1,12 +1,13 @@
 """Threshold handling
 
-Required thresholds fault if no metric:
+Required thresholds fault if there's no value for metric, but the fault
+will not escalate:
 
     >>> r = Threshold(
     ...     'foo critical > 200 warning > 50 error > 99 clear < 80').check
     >>> r([dict(name='foo', value=42)])
     >>> pp(r([]))
-    {'message': 'Missing metric', 'severity': 40}
+    {'escalates': False, 'message': 'Missing metric', 'severity': 40}
 
     >>> o = Threshold('foo ? warning >= 50 error >= 99').check
     >>> o([dict(name='foo', value=42)])
@@ -94,7 +95,11 @@ class Threshold:
         v = [m for m in metrics if m['name'] == self.name]
         if not v:
             if not self.optional:
-                return dict(severity=logging.ERROR, message='Missing metric')
+                return dict(
+                    escalates=False,
+                    message='Missing metric',
+                    severity=logging.ERROR,
+                    )
             return
         [v] = v
         v = v['value']


### PR DESCRIPTION
Support non-escalating faults, and use them for failures in monitors.

These should not be used when reporting application failures.

Addresses https://github.com/zc/cimaa/issues/15.
